### PR TITLE
Piper/library updates

### DIFF
--- a/asyncio_run_in_process/_child.py
+++ b/asyncio_run_in_process/_child.py
@@ -16,6 +16,7 @@ from typing import (
 from ._utils import (
     pickle_value,
     receive_pickled_value,
+    RemoteException,
 )
 from .state import (
     State,
@@ -204,8 +205,10 @@ def _run_process(parent_pid: int, fd_read: int, fd_write: int) -> None:
                 result = loop.run_until_complete(
                     _do_async_fn(async_fn, args, to_parent, loop),
                 )
-            except BaseException as err:
-                finished_payload = pickle_value(err)
+            except BaseException:
+                _, exc_value, exc_tb = sys.exc_info()
+                remote_exc = RemoteException(exc_value, exc_tb)
+                finished_payload = pickle_value(remote_exc)
                 raise
             finally:
                 # state: STOPPING

--- a/asyncio_run_in_process/_child.py
+++ b/asyncio_run_in_process/_child.py
@@ -25,7 +25,7 @@ from .typing import (
     TReturn,
 )
 
-logger = logging.getLogger("asyncio-run-in-process")
+logger = logging.getLogger("asyncio_run_in_process")
 
 
 #

--- a/asyncio_run_in_process/_utils.py
+++ b/asyncio_run_in_process/_utils.py
@@ -1,5 +1,8 @@
 import io
+import os
 import sys
+import traceback
+from types import TracebackType
 from typing import (
     Any,
     BinaryIO,
@@ -51,3 +54,30 @@ def receive_pickled_value(stream: BinaryIO) -> Any:
     serialized_len = int.from_bytes(len_bytes, "big")
     serialized_result = read_exactly(stream, serialized_len)
     return cloudpickle.loads(serialized_result)
+
+
+class RemoteTraceback(Exception):
+
+    def __init__(self, tb: str) -> None:
+        self.tb = tb
+
+    def __str__(self) -> str:
+        return self.tb
+
+
+class RemoteException(Exception):
+    def __init__(self, exc: Exception, tb: TracebackType) -> None:
+        self.tb = (
+            f'\n""" (exception from process: {os.getpid()})\n'
+            f"{''.join(traceback.format_exception(type(exc), exc, tb))}"
+            '"""'
+        )
+        self.exc = exc
+
+    def __reduce__(self) -> Any:
+        return rebuild_exc, (self.exc, self.tb)
+
+
+def rebuild_exc(exc, tb):  # type: ignore
+    exc.__cause__ = RemoteTraceback(tb)
+    return exc

--- a/asyncio_run_in_process/_utils.py
+++ b/asyncio_run_in_process/_utils.py
@@ -77,6 +77,10 @@ class RemoteException(Exception):
         self.exc = exc
 
     def __reduce__(self) -> Any:
+        """
+        Trick the `pickle` module into recreating this as the original
+        exception when the value gets unpickled.
+        """
         return rebuild_exc, (self.exc, self.tb)
 
 

--- a/asyncio_run_in_process/_utils.py
+++ b/asyncio_run_in_process/_utils.py
@@ -2,7 +2,9 @@ import io
 import os
 import sys
 import traceback
-from types import TracebackType
+from types import (
+    TracebackType,
+)
 from typing import (
     Any,
     BinaryIO,
@@ -66,7 +68,7 @@ class RemoteTraceback(Exception):
 
 
 class RemoteException(Exception):
-    def __init__(self, exc: Exception, tb: TracebackType) -> None:
+    def __init__(self, exc: BaseException, tb: TracebackType) -> None:
         self.tb = (
             f'\n""" (exception from process: {os.getpid()})\n'
             f"{''.join(traceback.format_exception(type(exc), exc, tb))}"

--- a/asyncio_run_in_process/run_in_process.py
+++ b/asyncio_run_in_process/run_in_process.py
@@ -36,7 +36,7 @@ from .typing import (
     TReturn,
 )
 
-logger = logging.getLogger("asyncio-run-in-process")
+logger = logging.getLogger("asyncio_run_in_process")
 
 
 async def _monitor_sub_proc(

--- a/asyncio_run_in_process/run_in_process.py
+++ b/asyncio_run_in_process/run_in_process.py
@@ -159,7 +159,9 @@ async def _monitor_state(
     )
 
 
-RELAY_SIGNALS = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+# SIGINT isn't included here because it's handled by catching the
+# `KeyboardInterrupt` exception.
+RELAY_SIGNALS = (signal.SIGTERM, signal.SIGHUP)
 
 
 def open_in_process(

--- a/asyncio_run_in_process/run_in_process.py
+++ b/asyncio_run_in_process/run_in_process.py
@@ -91,9 +91,9 @@ async def _relay_signals(
 
 
 async def _monitor_state(
-    proc: ProcessAPI[TReturn], parent_r: int, loop: asyncio.AbstractEventLoop,
+    proc: ProcessAPI[TReturn], parent_read_fd: int, loop: asyncio.AbstractEventLoop,
 ) -> None:
-    with os.fdopen(parent_r, "rb", closefd=True) as from_child:
+    with os.fdopen(parent_read_fd, "rb", closefd=True) as from_child:
         for expected_state in State:
             if proc.state is not expected_state:
                 raise InvalidState(

--- a/tests/core/test_remote_exception.py
+++ b/tests/core/test_remote_exception.py
@@ -4,7 +4,9 @@ import sys
 
 import cloudpickle
 
-from asyncio_run_in_process._utils import RemoteException
+from asyncio_run_in_process._utils import (
+    RemoteException,
+)
 
 
 def test_RemoteException(caplog):

--- a/tests/core/test_remote_exception.py
+++ b/tests/core/test_remote_exception.py
@@ -1,0 +1,41 @@
+import logging
+import os
+import sys
+
+import cloudpickle
+
+from asyncio_run_in_process._utils import RemoteException
+
+
+def test_RemoteException(caplog):
+    logger = logging.getLogger('asyncio_run_in_process.testing')
+
+    def recorder_func():
+        try:
+            outer_func()
+        except Exception:
+            _, exc_value, exc_tb = sys.exc_info()
+            remote_err = RemoteException(exc_value, exc_tb)
+
+        local_err = cloudpickle.loads(cloudpickle.dumps(remote_err))
+
+        try:
+            raise local_err
+        except BaseException:
+            logger.debug("Got Error:", exc_info=True)
+
+        return local_err
+
+    def outer_func():
+        inner_func()
+
+    def inner_func():
+        raise ValueError("Some Error")
+
+    with caplog.at_level(logging.DEBUG):
+        local_err = recorder_func()
+    assert isinstance(local_err, ValueError)
+    assert "Some Error" in caplog.text
+    assert "outer_func" in caplog.text
+    assert "inner_func" in caplog.text
+    assert str(os.getpid()) in caplog.text


### PR DESCRIPTION
replaces #2

## What was wrong?

There are a few things that came up while battle testing the library:

- A `SIGINT` to a child process wasn't resulting in a `KeyboardInterrupt` being raised in the running coroutine.
- Each `SIGINT` in the parent process was being sent to the child process twice.
- There was a race condition in the parent process reading the result from a child process that caused the parent process to try and read from a closed file descriptor.
- Traceback info from exceptions in the child process was not preserved.


## How was it fixed?

- `SIGINT` for the child process now properly injects the `KeyboardInterrupt` exception into the running coroutine.
- Fixed closed file descriptor race condition by having the `_monitor_state` function handle the lifecycle of the file descriptor.
- Created `RemoteTraceback` which does a best approximation of preserving the original traceback information.

#### Cute Animal Picture


![rawik2cu2p5x](https://user-images.githubusercontent.com/824194/68887908-1cd9ea00-06d7-11ea-8974-c62f7ebd2cbc.jpg)
