### PR TITLE
Add ability to pass kwargs to the subprocess

### DIFF
--- a/asyncio_run_in_process/run_in_process.py
+++ b/asyncio_run_in_process/run_in_process.py
@@ -221,8 +221,6 @@ async def _open_in_process(
 
     sub_proc = await asyncio.create_subprocess_exec(
         *command,
-        # mypy doesn't recognize that loop can be `None`
-        loop=loop,  # type: ignore
         **_update_subprocess_kwargs(subprocess_kwargs, child_r, child_w),
     )
     if loop is None:

--- a/asyncio_run_in_process/typing.py
+++ b/asyncio_run_in_process/typing.py
@@ -43,33 +43,33 @@ if TYPE_CHECKING:
             'env': Optional[Mapping[str, str]],
             'startupinfo': Optional[STARTUPINFO],
             'creationflags': Optional[Union[
-                Union[
-                    Literal[subprocess.CREATE_NEW_CONSOLE],  # type: ignore
-                    Literal[subprocess.CREATE_NEW_PROCESS_GROUP],  # type: ignore
-                    Literal[subprocess.ABOVE_NORMAL_PRIORITY_CLASS],  # type: ignore
-                    Literal[subprocess.BELOW_NORMAL_PRIORITY_CLASS],  # type: ignore
-                    Literal[subprocess.HIGH_PRIORITY_CLASS],  # type: ignore
-                    Literal[subprocess.IDLE_PRIORITY_CLASS],  # type: ignore
-                    Literal[subprocess.NORMAL_PRIORITY_CLASS],  # type: ignore
-                    Literal[subprocess.REALTIME_PRIORITY_CLASS],  # type: ignore
-                    Literal[subprocess.CREATE_NO_WINDOW],  # type: ignore
-                    Literal[subprocess.DETACHED_PROCESS],  # type: ignore
-                    Literal[subprocess.CREATE_DEFAULT_ERROR_MODE],  # type: ignore
-                    Literal[subprocess.CREATE_BREAKAWAY_FROM_JOB],  # type: ignore
+                Literal[
+                    subprocess.CREATE_NEW_CONSOLE,  # type: ignore
+                    subprocess.CREATE_NEW_PROCESS_GROUP,  # type: ignore
+                    subprocess.ABOVE_NORMAL_PRIORITY_CLASS,  # type: ignore
+                    subprocess.BELOW_NORMAL_PRIORITY_CLASS,  # type: ignore
+                    subprocess.HIGH_PRIORITY_CLASS,  # type: ignore
+                    subprocess.IDLE_PRIORITY_CLASS,  # type: ignore
+                    subprocess.NORMAL_PRIORITY_CLASS,  # type: ignore
+                    subprocess.REALTIME_PRIORITY_CLASS,  # type: ignore
+                    subprocess.CREATE_NO_WINDOW,  # type: ignore
+                    subprocess.DETACHED_PROCESS,  # type: ignore
+                    subprocess.CREATE_DEFAULT_ERROR_MODE,  # type: ignore
+                    subprocess.CREATE_BREAKAWAY_FROM_JOB,  # type: ignore
                 ],
-                Sequence[Union[
-                    Literal[subprocess.CREATE_NEW_CONSOLE],
-                    Literal[subprocess.CREATE_NEW_PROCESS_GROUP],
-                    Literal[subprocess.ABOVE_NORMAL_PRIORITY_CLASS],
-                    Literal[subprocess.BELOW_NORMAL_PRIORITY_CLASS],
-                    Literal[subprocess.HIGH_PRIORITY_CLASS],
-                    Literal[subprocess.IDLE_PRIORITY_CLASS],
-                    Literal[subprocess.NORMAL_PRIORITY_CLASS],
-                    Literal[subprocess.REALTIME_PRIORITY_CLASS],
-                    Literal[subprocess.CREATE_NO_WINDOW],
-                    Literal[subprocess.DETACHED_PROCESS],
-                    Literal[subprocess.CREATE_DEFAULT_ERROR_MODE],
-                    Literal[subprocess.CREATE_BREAKAWAY_FROM_JOB],
+                Sequence[Literal[
+                    subprocess.CREATE_NEW_CONSOLE,
+                    subprocess.CREATE_NEW_PROCESS_GROUP,
+                    subprocess.ABOVE_NORMAL_PRIORITY_CLASS,
+                    subprocess.BELOW_NORMAL_PRIORITY_CLASS,
+                    subprocess.HIGH_PRIORITY_CLASS,
+                    subprocess.IDLE_PRIORITY_CLASS,
+                    subprocess.NORMAL_PRIORITY_CLASS,
+                    subprocess.REALTIME_PRIORITY_CLASS,
+                    subprocess.CREATE_NO_WINDOW,
+                    subprocess.DETACHED_PROCESS,
+                    subprocess.CREATE_DEFAULT_ERROR_MODE,
+                    subprocess.CREATE_BREAKAWAY_FROM_JOB,
                 ]],
             ]],
         },

--- a/asyncio_run_in_process/typing.py
+++ b/asyncio_run_in_process/typing.py
@@ -1,5 +1,80 @@
+import os
 from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Callable,
     TypeVar,
 )
+
+if TYPE_CHECKING:
+    import subprocess
+    from typing import Mapping, Optional, Sequence, Union
+
+    from .typing_compat import Literal, TypedDict
+
+    try:
+        # mypy knows this isn't present in <=3.6
+        from subprocess import STARTUPINFO  # type: ignore
+    except ImportError:
+        # STARTUPINFO added in 3.7+
+        STARTUPINFO = Any
+
+    PIPE = Literal[subprocess.PIPE]
+    DEVNULL = Literal[subprocess.DEVNULL]
+    STDOUT = Literal[subprocess.STDOUT]
+
+    SubprocessKwargs = TypedDict(
+        'SubprocessKwargs',
+        # no: bufsize, universal_newlines, shell, text, encoding and errors
+        {
+            'stdin': Optional[Union[IO, PIPE, DEVNULL]],
+            'stdout': Optional[Union[IO, PIPE, DEVNULL]],
+            'stderr': Optional[Union[IO, PIPE, DEVNULL, STDOUT]],
+
+            'limit': Optional[int],
+
+            'preexec_fn': Callable[..., Any],
+            'close_fds': Optional[bool],
+            'pass_fds': Optional[Sequence[int]],
+            'cdw': Optional[os.PathLike],
+            'restore_signals': Optional[bool],
+            'start_new_session': Optional[bool],
+            'env': Optional[Mapping[str, str]],
+            'startupinfo': Optional[STARTUPINFO],
+            'creationflags': Optional[Union[
+                Union[
+                    Literal[subprocess.CREATE_NEW_CONSOLE],  # type: ignore
+                    Literal[subprocess.CREATE_NEW_PROCESS_GROUP],  # type: ignore
+                    Literal[subprocess.ABOVE_NORMAL_PRIORITY_CLASS],  # type: ignore
+                    Literal[subprocess.BELOW_NORMAL_PRIORITY_CLASS],  # type: ignore
+                    Literal[subprocess.HIGH_PRIORITY_CLASS],  # type: ignore
+                    Literal[subprocess.IDLE_PRIORITY_CLASS],  # type: ignore
+                    Literal[subprocess.NORMAL_PRIORITY_CLASS],  # type: ignore
+                    Literal[subprocess.REALTIME_PRIORITY_CLASS],  # type: ignore
+                    Literal[subprocess.CREATE_NO_WINDOW],  # type: ignore
+                    Literal[subprocess.DETACHED_PROCESS],  # type: ignore
+                    Literal[subprocess.CREATE_DEFAULT_ERROR_MODE],  # type: ignore
+                    Literal[subprocess.CREATE_BREAKAWAY_FROM_JOB],  # type: ignore
+                ],
+                Sequence[Union[
+                    Literal[subprocess.CREATE_NEW_CONSOLE],
+                    Literal[subprocess.CREATE_NEW_PROCESS_GROUP],
+                    Literal[subprocess.ABOVE_NORMAL_PRIORITY_CLASS],
+                    Literal[subprocess.BELOW_NORMAL_PRIORITY_CLASS],
+                    Literal[subprocess.HIGH_PRIORITY_CLASS],
+                    Literal[subprocess.IDLE_PRIORITY_CLASS],
+                    Literal[subprocess.NORMAL_PRIORITY_CLASS],
+                    Literal[subprocess.REALTIME_PRIORITY_CLASS],
+                    Literal[subprocess.CREATE_NO_WINDOW],
+                    Literal[subprocess.DETACHED_PROCESS],
+                    Literal[subprocess.CREATE_DEFAULT_ERROR_MODE],
+                    Literal[subprocess.CREATE_BREAKAWAY_FROM_JOB],
+                ]],
+            ]],
+        },
+        total=False,
+    )
+
 
 TReturn = TypeVar("TReturn")

--- a/asyncio_run_in_process/typing_compat.py
+++ b/asyncio_run_in_process/typing_compat.py
@@ -1,0 +1,7 @@
+try:
+    # mypy knows that `TypedDict` and `Literal` don't exist in <3.8
+    from typing import TypedDict, Literal  # type: ignore
+except ImportError:
+    # TypedDict is only available in python 3.8+
+    # Literal is only available in python 3.8+
+    from typing_extensions import TypedDict, Literal  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         "isort>=4.2.15,<5",
         "mypy==0.740",
         "pydocstyle>=3.0.0,<4",
-        "typing-extensions==3.7.4.1",
+        "typing-extensions>=3.7.4.1,<4;python_version<'3.8'",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ extras_require = {
         "isort>=4.2.15,<5",
         "mypy==0.740",
         "pydocstyle>=3.0.0,<4",
+        "typing-extensions==3.7.4.1",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",

--- a/tests/core/test_run_in_process.py
+++ b/tests/core/test_run_in_process.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from pathlib import (
     Path,
 )
@@ -36,3 +37,18 @@ async def test_run_in_process_with_error():
 
     with pytest.raises(ValueError, match="Some err"):
         await asyncio.wait_for(run_in_process(raise_err), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_run_in_process_pass_environment_variables():
+    # sanity
+    assert 'ASYNC_RUN_IN_PROCESS_ENV_TEST' not in os.environ
+
+    async def return_env():
+        return os.environ['ASYNC_RUN_IN_PROCESS_ENV_TEST']
+
+    value = await run_in_process(
+        return_env,
+        subprocess_kwargs={'env': {'ASYNC_RUN_IN_PROCESS_ENV_TEST': 'test-value'}},
+    )
+    assert value == 'test-value'


### PR DESCRIPTION
## What was wrong?

Using `asyncio-run-in-process` with `uvloop` in tests causes an error because uvloop doesn't like the mocked stdin/stdout/stderr that pytest sets up.  Without the ability to use `subprocess.PIPE` for these this means that you can't run tests that use this library.

## How was it fixed?

Expose the ability to pass the various kwargs that are supported by `asyncio.open_subprocess_exec`

#### Cute Animal Picture

![seal-pups-9](https://user-images.githubusercontent.com/824194/70552639-02105f00-1b37-11ea-9702-8f7bdf8ca736.jpg)
