### PR TITLE
Fix hang when exception happens inside context block

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,12 +60,6 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
-  pypy3-core:
-    <<: *common
-    docker:
-      - image: pypy
-        environment:
-          TOXENV: pypy3-core
 workflows:
   version: 2
   test:
@@ -74,4 +68,3 @@ workflows:
       - lint
       - py36-core
       - py37-core
-      - pypy3-core

--- a/asyncio_run_in_process/constants.py
+++ b/asyncio_run_in_process/constants.py
@@ -1,0 +1,10 @@
+# The number of seconds that are given to a child process to exit after the
+# parent process gets a KeyboardInterrupt/SIGINT-signal and sends a `SIGINT` to
+# the child process.
+SIGINT_TIMEOUT_SECONDS = 2
+
+
+# The number of seconds that are givent to a child process to exit after the
+# parent process gets an `asyncio.CancelledError` which results in sending a
+# `SIGTERM` to the child process.
+SIGTERM_TIMEOUT_SECONDS = 2

--- a/asyncio_run_in_process/run_in_process.py
+++ b/asyncio_run_in_process/run_in_process.py
@@ -26,6 +26,10 @@ from ._utils import (
 from .abc import (
     ProcessAPI,
 )
+from .constants import (
+    SIGINT_TIMEOUT_SECONDS,
+    SIGTERM_TIMEOUT_SECONDS,
+)
 from .exceptions import (
     InvalidState,
 )
@@ -265,7 +269,7 @@ async def _open_in_process(
                 try:
                     proc.send_signal(signal.SIGINT)
                     try:
-                        await asyncio.wait_for(proc.wait(), timeout=2)
+                        await asyncio.wait_for(proc.wait(), timeout=SIGINT_TIMEOUT_SECONDS)
                     except asyncio.TimeoutError:
                         logger.debug(
                             "Timed out waiting for pid=%d to exit after relaying SIGINT",
@@ -285,7 +289,7 @@ async def _open_in_process(
                 try:
                     proc.terminate()
                     try:
-                        await asyncio.wait_for(proc.wait(), timeout=2)
+                        await asyncio.wait_for(proc.wait(), timeout=SIGTERM_TIMEOUT_SECONDS)
                     except asyncio.TimeoutError:
                         logger.debug(
                             "Timed out waiting for pid=%d to exit after SIGTERM",

--- a/tests/core/test_open_in_process.py
+++ b/tests/core/test_open_in_process.py
@@ -129,3 +129,21 @@ async def test_open_proc_outer_KeyboardInterrupt():
         async with open_in_process(do_sleep_forever) as proc:
             raise KeyboardInterrupt
     assert proc.returncode == 2
+
+
+class CustomException(BaseException):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_open_proc_does_not_hang_on_exception():
+    async def do_sleep_forever():
+        while True:
+            await asyncio.sleep(0)
+
+    async def _do_inner():
+        with pytest.raises(CustomException):
+            async with open_in_process(do_sleep_forever):
+                raise CustomException("Just a boring exception")
+
+    await asyncio.wait_for(_do_inner(), timeout=1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,py3}-core
+    py{36,37}-core
     lint
     doctest
 
@@ -28,7 +28,6 @@ basepython =
     doctest: python
     py36: python3.6
     py37: python3.7
-    pypy3: pypy3
 extras=
     test
     doctest: doc


### PR DESCRIPTION
Builds on #9 

## What was wrong?

The `open_in_process` context manager implementation was resulting in processes hanging when an exception occured within the context block.  This was due to a `finally` statement that did `await proc.wait()`

## How was it fixed?

Adjusted the error handling to more appropriately capture the intended semantics.

- if `KeyboardInterrupt` then we send a `SIGINT` to the child process and wait a moment to let it shutdown cleanly.
- if `asyncio.CancelledError` we send a `SIGTERM` to the child process and wait a moment to let it shutdown cleanly.
- if context exits without exception we do `await proc.wait()`
- if context exits with an unknown exception **or** the `SIGINT/SIGTERM` shutdowns timeout then we do a `SIGKILL`.

#### Cute Animal Picture

![seal611](https://user-images.githubusercontent.com/824194/70644433-3b60d180-1c00-11ea-8b24-2c7a84d3906a.jpg)

