### PR TITLE
Ensure SubprocessKwargs type is easy to import

### DIFF
--- a/asyncio_run_in_process/typing.py
+++ b/asyncio_run_in_process/typing.py
@@ -4,10 +4,15 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     TypeVar,
 )
 
 if TYPE_CHECKING:
+    #
+    # This block ensures that typing_extensions isn't needed during runtime and
+    # is only necessary for linting.
+    #
     import subprocess
     from typing import Mapping, Optional, Sequence, Union
 
@@ -75,6 +80,11 @@ if TYPE_CHECKING:
         },
         total=False,
     )
+else:
+    # Ensure this is importable outside of the `TYPE_CHECKING` context so that
+    # 3rd party libraries can use this as a type without having to think too
+    # much about what they are doing.
+    SubprocessKwargs = Dict[str, Any]
 
 
 TReturn = TypeVar("TReturn")


### PR DESCRIPTION
## What was wrong?

The `SubprocessKwargs` type should be exposed to 3rd party libraries in a reliable way.

## How was it fixed?

Ensured that an import of `from asyncio_run_in_process.typing import SubprocessKwargs` will always work.

#### Cute Animal Picture

![young-grey-seal-pup-halichoerus-grypus-orkney](https://user-images.githubusercontent.com/824194/70646367-fd65ac80-1c03-11ea-98d3-87f9e13ed393.jpg)
