### PR TITLE
Async calls raise RuntimeError when called after catching KeyboardInterrupt

### DIFF
--- a/asyncio_run_in_process/_child.py
+++ b/asyncio_run_in_process/_child.py
@@ -217,6 +217,7 @@ def _run_process(parent_pid: int, fd_read: int, fd_write: int) -> None:
         except SystemExit as err:
             code = err.args[0]
         except BaseException:
+            logger.exception("")
             code = 1
         else:
             finished_payload = pickle_value(result)

--- a/asyncio_run_in_process/run_in_process.py
+++ b/asyncio_run_in_process/run_in_process.py
@@ -265,7 +265,7 @@ async def _open_in_process(
                 # If a keyboard interrupt is encountered relay it to the
                 # child process and then give it a moment to cleanup before
                 # re-raising
-                logger.debug("Relaying SIGINT to pid=%d", sub_proc.pid)
+                logger.info("Relaying SIGINT to pid=%d", sub_proc.pid)
                 try:
                     proc.send_signal(signal.SIGINT)
                     try:
@@ -281,7 +281,7 @@ async def _open_in_process(
                 # If this is due to an `asyncio` cancellation we send along a
                 # SIGTERM to signal the need for more immediate cleanup, giving
                 # the child process a moment to finish before re-raising.
-                logger.debug(
+                logger.info(
                     "Got CancelledError while running subprocess pid=%d.  Sending SIGTERM.",
                     sub_proc.pid,
                 )
@@ -290,7 +290,7 @@ async def _open_in_process(
                     try:
                         await asyncio.wait_for(proc.wait(), timeout=SIGTERM_TIMEOUT_SECONDS)
                     except asyncio.TimeoutError:
-                        logger.debug(
+                        logger.info(
                             "Timed out waiting for pid=%d to exit after SIGTERM",
                             sub_proc.pid,
                         )

--- a/tests/core/test_open_in_process.py
+++ b/tests/core/test_open_in_process.py
@@ -51,6 +51,7 @@ async def test_open_proc_SIGINT_can_be_handled():
             while True:
                 await asyncio.sleep(0)
         except KeyboardInterrupt:
+            await asyncio.sleep(0.001)
             return 9999
 
     async with open_in_process(do_sleep_forever) as proc:
@@ -71,7 +72,7 @@ async def test_open_proc_SIGINT_can_be_ignored():
 
         try:
             while True:
-                await asyncio.sleep(0)
+                await asyncio.sleep(0.001)
         except KeyboardInterrupt:
             return 9999
 
@@ -123,7 +124,7 @@ async def test_open_proc_unpickleable_params(touch_path):
 async def test_open_proc_outer_KeyboardInterrupt():
     async def do_sleep_forever():
         while True:
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.0001)
 
     with pytest.raises(KeyboardInterrupt):
         async with open_in_process(do_sleep_forever) as proc:

--- a/tests/core/test_open_in_process.py
+++ b/tests/core/test_open_in_process.py
@@ -46,6 +46,7 @@ async def test_open_proc_SIGINT_while_running():
 
 @pytest.mark.asyncio
 async def test_open_proc_SIGINT_can_be_handled():
+
     async def do_sleep_forever():
         try:
             while True:


### PR DESCRIPTION
When we get a SIGINT, we inject a `KeyboardInterrupt` into our child process
(https://github.com/ethereum/asyncio-run-in-process/blob/master/asyncio_run_in_process/_child.py#L105),
but as I described in https://github.com/ethereum/trinity/issues/1613, any async calls made when
handling a `KeyboardInterrupt` inside the child seemed to raise another `KeyboardInterrupt`. I've
been trying to figure out what's going on and although I haven't had any luck so far, I've managed
to get a similar behavior in the tests here, so I'm posting this to see if anybody has any idea
what's going on

As you can see, our tests were using `await asyncio.sleep(0)`, to simulate an asynchoronous cleanup
after a KeyboardInterrupt is caught, but that doesn't seem to have the same effect as a non-zero sleep.
With the non-zero sleep we get a crash similar to the one I describe in that trinity issue, although
here it seems to manifest itself as a RuntimeError.