### PR TITLE
A couple changes related to task/child cancellation

### DIFF
--- a/asyncio_run_in_process/abc.py
+++ b/asyncio_run_in_process/abc.py
@@ -102,13 +102,12 @@ class ProcessAPI(ABC, Generic[TReturn]):
     #
     # Result
     #
-    @property
     @abstractmethod
-    def result(self) -> TReturn:
+    def get_result_or_raise(self) -> TReturn:
         ...
 
     @abstractmethod
-    async def wait_result(self) -> TReturn:
+    async def wait_result_or_raise(self) -> TReturn:
         ...
 
     #

--- a/asyncio_run_in_process/exceptions.py
+++ b/asyncio_run_in_process/exceptions.py
@@ -8,3 +8,7 @@ class ProcessKilled(BaseRunInProcessException):
 
 class InvalidState(BaseRunInProcessException):
     pass
+
+
+class ChildCancelled(BaseRunInProcessException):
+    pass

--- a/asyncio_run_in_process/process.py
+++ b/asyncio_run_in_process/process.py
@@ -207,16 +207,11 @@ class Process(ProcessAPI[TReturn]):
     #
     # Result
     #
-    @property
-    def result(self) -> TReturn:
+    def get_result_or_raise(self) -> TReturn:
         """
-        Return the computed result from the process.
+        Return the computed result from the process, raising if it was an exception.
 
         If the process has not finished then raises an `AttributeError`
-
-        If the process raised an exception, that exception is raised.
-
-        Otherwise returns the result of the process.
         """
         if self._error is None and not hasattr(self, "_return_value"):
             raise AttributeError("Process not done")
@@ -227,7 +222,7 @@ class Process(ProcessAPI[TReturn]):
         else:
             raise BaseException("Code path should be unreachable")
 
-    async def wait_result(self) -> TReturn:
+    async def wait_result_or_raise(self) -> TReturn:
         """
         Block until the process has exited, either returning the return value
         if execution was successful, or raising an exception if it failed

--- a/tests/core/test_process_object.py
+++ b/tests/core/test_process_object.py
@@ -68,7 +68,7 @@ async def test_Process_object_wait_for_result_when_error():
 
     async with open_in_process(raise_error) as proc:
         with pytest.raises(ValueError, match="child-error"):
-            await asyncio.wait_for(proc.wait_result(), timeout=2)
+            await asyncio.wait_for(proc.wait_result_or_raise(), timeout=2)
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,7 @@ async def test_Process_object_wait_for_result_when_return_value():
         return 7
 
     async with open_in_process(return7) as proc:
-        result = await asyncio.wait_for(proc.wait_result(), timeout=2)
+        result = await asyncio.wait_for(proc.wait_result_or_raise(), timeout=2)
         assert result == 7
         assert proc.error is None
 


### PR DESCRIPTION
1. When the task running open_in_process() is cancelled, we now send
   a SIGINT and give the child a chance to terminate before sending
   a SIGTERM.
2. When a child raises asyncio.CancelledError, that gets converted
   into a ChildCancelled exception

Also renames `Process.@result` to `Process.get_result_or_raise()` as
having a property that is expected to raise an exception is at
the very least unexpected.