### PR TITLE
Make Process.__str__ more useful

### DIFF
--- a/asyncio_run_in_process/process.py
+++ b/asyncio_run_in_process/process.py
@@ -48,7 +48,7 @@ class Process(ProcessAPI[TReturn]):
         self._state_changed = asyncio.Condition()
 
     def __str__(self) -> str:
-        return f"Process[{self._async_fn.__name__}]"
+        return f"Process[{self._async_fn}]"
 
     #
     # State


### PR DESCRIPTION
Before it'd include just the __name__ of its async_fn, which is not
useful at all when we use a classmethod (like in trinity), as it
gives no clue as to what subclass/instance was actually used