### PR TITLE
Wait for proc to reach EXECUTING state before yielding

### DIFF
--- a/asyncio_run_in_process/constants.py
+++ b/asyncio_run_in_process/constants.py
@@ -1,3 +1,7 @@
+# Number of seconds given to a child to reach the EXECUTING state before we yield in
+# open_in_process().
+STARTUP_TIMEOUT_SECONDS = 5
+
 # The number of seconds that are given to a child process to exit after the
 # parent process gets a KeyboardInterrupt/SIGINT-signal and sends a `SIGINT` to
 # the child process.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ to run synchronous code, you must ensure the task/process terminates in case the
 ``loop.run_in_executor()`` call is cancelled, or else ``open_in_process`` will not
 ever return. This is necessary because asyncio does not cancel the thread/process it
 starts (in ``loop.run_in_executor()``), and that prevents ``open_in_process`` from
-terminating. One way to ensure that is to have the code runnin in the executor react
+terminating. One way to ensure that is to have the code running in the executor react
 to an event that gets set when ``loop.run_in_executor()`` returns.
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
         "tox>=2.9.1,<3",
     ],
     'lint': [
-        "flake8==3.4.1",
+        "flake8==3.7.9",
         "isort>=4.2.15,<5",
         "mypy==0.770",
         "pydocstyle>=3.0.0,<4",


### PR DESCRIPTION
## What was wrong?

`open_in_process()` yielded as soon as the sub process reached the STARTED state, which is before
the signal handlers have been setup, so a signal sent immediately after open_in_process()
yielded would not be properly handled

## How was it fixed?

Wait for proc to reach EXECUTING state before yielding. Also use a timeout when waiting so that we
don't hang forever in case the process never reaches that state.