### PR TITLE
Make max number of simultaneous processes configurable

### DIFF
--- a/asyncio_run_in_process/__init__.py
+++ b/asyncio_run_in_process/__init__.py
@@ -3,7 +3,7 @@ from .exceptions import (  # noqa: F401
     InvalidState,
     ProcessKilled,
 )
-from .run_in_process import (  # noqa: F401
+from .main import (  # noqa: F401
     open_in_process,
     open_in_process_with_trio,
     run_in_process,

--- a/asyncio_run_in_process/_child.py
+++ b/asyncio_run_in_process/_child.py
@@ -208,6 +208,7 @@ def run_process(runner: TEngineRunner, fd_read: int, fd_write: int) -> None:
         except SystemExit as err:
             code = err.args[0]
         except BaseException:
+            logger.exception("%s raised an unexpected exception", async_fn)
             code = 1
         else:
             code = 0

--- a/asyncio_run_in_process/_child.py
+++ b/asyncio_run_in_process/_child.py
@@ -180,7 +180,7 @@ def _run_on_asyncio(async_fn: TAsyncFn, args: Sequence[Any], to_parent: BinaryIO
         update_state_finished(to_parent, finished_payload)
 
 
-def run_process(runner: TEngineRunner, parent_pid: int, fd_read: int, fd_write: int) -> None:
+def run_process(runner: TEngineRunner, fd_read: int, fd_write: int) -> None:
     """
     Run the child process.
 
@@ -220,9 +220,6 @@ def run_process(runner: TEngineRunner, parent_pid: int, fd_read: int, fd_write: 
 #
 parser = argparse.ArgumentParser(description="asyncio-run-in-process")
 parser.add_argument(
-    "--parent-pid", type=int, required=True, help="The PID of the parent process"
-)
-parser.add_argument(
     "--fd-read",
     type=int,
     required=True,
@@ -246,7 +243,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     run_process(
         runner=_run_on_asyncio,
-        parent_pid=args.parent_pid,
         fd_read=args.fd_read,
         fd_write=args.fd_write,
     )

--- a/asyncio_run_in_process/_child_trio.py
+++ b/asyncio_run_in_process/_child_trio.py
@@ -78,7 +78,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     run_process(
         runner=_run_on_trio,
-        parent_pid=args.parent_pid,
         fd_read=args.fd_read,
         fd_write=args.fd_write,
     )

--- a/asyncio_run_in_process/_utils.py
+++ b/asyncio_run_in_process/_utils.py
@@ -20,9 +20,7 @@ from async_generator import (
 import cloudpickle
 
 
-def get_subprocess_command(
-    child_r: int, child_w: int, parent_pid: int, use_trio: bool,
-) -> Tuple[str, ...]:
+def get_subprocess_command(child_r: int, child_w: int, use_trio: bool) -> Tuple[str, ...]:
     if use_trio:
         from . import _child_trio as child_runner
     else:
@@ -32,8 +30,6 @@ def get_subprocess_command(
         sys.executable,
         "-m",
         child_runner.__name__,
-        "--parent-pid",
-        str(parent_pid),
         "--fd-read",
         str(child_r),
         "--fd-write",

--- a/asyncio_run_in_process/constants.py
+++ b/asyncio_run_in_process/constants.py
@@ -1,5 +1,6 @@
-# Number of seconds given to a child to reach the EXECUTING state before we yield in
-# open_in_process().
+# Default number of seconds given to a child to reach the EXECUTING state before we yield in
+# open_in_process(). Can be overwritten by the ASYNCIO_RUN_IN_PROCESS_STARTUP_TIMEOUT
+# environment variable.
 STARTUP_TIMEOUT_SECONDS = 5
 
 # The number of seconds that are given to a child process to exit after the
@@ -7,8 +8,11 @@ STARTUP_TIMEOUT_SECONDS = 5
 # the child process.
 SIGINT_TIMEOUT_SECONDS = 2
 
-
 # The number of seconds that are givent to a child process to exit after the
 # parent process gets an `asyncio.CancelledError` which results in sending a
 # `SIGTERM` to the child process.
 SIGTERM_TIMEOUT_SECONDS = 2
+
+# Default maximum number of process that can be running at the same time. Can be overwritten via
+# the ASYNCIO_RUN_IN_PROCESS_MAX_PROCS environment variable.
+MAX_PROCESSES = 16

--- a/asyncio_run_in_process/run_in_process.py
+++ b/asyncio_run_in_process/run_in_process.py
@@ -255,9 +255,8 @@ async def _open_in_process(
 
     parent_r, child_w = os.pipe()
     child_r, parent_w = os.pipe()
-    parent_pid = os.getpid()
 
-    command = get_subprocess_command(child_r, child_w, parent_pid, use_trio)
+    command = get_subprocess_command(child_r, child_w, use_trio)
 
     sub_proc = await asyncio.create_subprocess_exec(
         *command,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,13 @@ run them with ``trio``, the ``run_in_process_with_trio`` and ``open_in_process_w
 functions can be used.
 
 
+Maximum number of running processes
+-----------------------------------
+
+By default we can only have up to ``MAX_PROCESSES`` running at any given moment, but that can
+be changed via the ``ASYNCIO_RUN_IN_PROCESS_MAX_PROCS`` environment variable.
+
+
 Gotchas
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import (
 
 extras_require = {
     'test': [
+        "async-exit-stack==1.0.1",
         "pytest==5.2.2",
         "pytest-asyncio==0.10.0",
         "pytest-xdist",


### PR DESCRIPTION
That limit has always existed but was implicit and undocumented. It is caused by the fact that
every running process will block one worker thread from the ThreadPoolExecutor (passed to
run_in_executor()). As we used the default executor, that limit could vary between python versions
(`cpu_count() * 5` on py37 but only `min(32, cpu_count() + 4)` on py38).

We now use our own ThreadPoolExecutor instead of the loop's default one.  That way we can make the
max number of processes configurable and avoid interfering with other code that uses the default
executor.