### PR TITLE
Raise InvalidDataFromChild if we can't unpickle result from child

### DIFF
--- a/asyncio_run_in_process/exceptions.py
+++ b/asyncio_run_in_process/exceptions.py
@@ -12,3 +12,17 @@ class InvalidState(BaseRunInProcessException):
 
 class ChildCancelled(BaseRunInProcessException):
     pass
+
+
+class UnpickleableValue(BaseRunInProcessException):
+    pass
+
+
+class InvalidDataFromChild(BaseRunInProcessException):
+    """
+    The child's return value cannot be unpickled.
+
+    This seems to happen only when the child raises a custom exception whose constructor has more
+    than one required argument: https://github.com/ethereum/asyncio-run-in-process/issues/28
+    """
+    pass


### PR DESCRIPTION
Closes: #28 